### PR TITLE
Allow litex leds to build without cas

### DIFF
--- a/litex/litex_leds.c
+++ b/litex/litex_leds.c
@@ -6,6 +6,15 @@
 
 #include "generated/csr.h"
 
+#ifndef CSR_CAS_BASE
+static inline unsigned char cas_leds_out_read(void) {
+	return 0;
+}
+
+static inline void cas_leds_out_write(unsigned char value) {
+}
+#endif
+
 const mp_obj_type_t litex_led_type;
 
 typedef struct _litex_led_obj_t {


### PR DESCRIPTION
This is needed to build micropython firmware for Opsis. The implementation is a stub as Opsis does not yet have any LEDs exposed in the gateware.

Resolves https://github.com/timvideos/HDMI2USB-litex-firmware/issues/344