### PR TITLE
Cas updates

### DIFF
--- a/litex/Makefile
+++ b/litex/Makefile
@@ -40,6 +40,7 @@ SRC_C = \
 	modmachine.c \
 	modlitex.c \
 	litex_leds.c \
+	litex_switches.c \
 	lib/utils/stdout_helpers.c \
 	lib/utils/interrupt_char.c \
 	lib/utils/pyexec.c \

--- a/litex/Makefile
+++ b/litex/Makefile
@@ -41,6 +41,7 @@ SRC_C = \
 	modlitex.c \
 	litex_leds.c \
 	litex_switches.c \
+	litex_buttons.c \
 	lib/utils/stdout_helpers.c \
 	lib/utils/interrupt_char.c \
 	lib/utils/pyexec.c \

--- a/litex/litex_buttons.c
+++ b/litex/litex_buttons.c
@@ -1,0 +1,96 @@
+
+#include "py/nlr.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "py/objexcept.h"
+
+#include "generated/csr.h"
+
+#ifndef CSR_CAS_BASE
+static inline unsigned char cas_buttons_ev_status_read(void) {
+	return 0;
+}
+
+static inline void cas_buttons_ev_status_write(unsigned char value) {}
+
+static inline unsigned char cas_buttons_ev_pending_read(void) {
+    return 0;
+}
+static inline void cas_buttons_ev_pending_write(unsigned char value) {}
+static inline unsigned char cas_buttons_ev_enable_read(void) {
+    return 0;
+}
+static inline void cas_buttons_ev_enable_write(unsigned char value) {}
+#define CAS_NUM_BUTTONS 0
+#endif
+
+const mp_obj_type_t litex_button_type;
+
+typedef struct _litex_button_obj_t {
+    mp_obj_base_t base;
+    int num;
+} litex_button_obj_t;
+
+
+STATIC mp_obj_t litex_button_make_new(const mp_obj_type_t *type_in,
+		size_t n_args, size_t n_kw, const mp_obj_t *args) {
+	mp_arg_check_num(n_args, n_kw, 1, 1, false);
+
+	mp_uint_t button_num = mp_obj_get_int(args[0]);
+
+    if ((button_num < 0) || (button_num > CAS_NUM_BUTTONS)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+			"not a valid BUTTON number: %d", button_num));
+	} else { 
+        litex_button_obj_t* button = m_new_obj(litex_button_obj_t);
+        button->base.type = type_in;
+        button->num = button_num;
+        return MP_OBJ_FROM_PTR(button);
+    }
+
+}
+
+void litex_button_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+	litex_button_obj_t *self = MP_OBJ_TO_PTR(self_in);
+	mp_printf(print, "button(%u)", self->num);
+}
+
+STATIC mp_obj_t litex_button_status_read(mp_obj_t self_in) {
+	litex_button_obj_t *button = MP_OBJ_TO_PTR(self_in);
+	bool state = cas_buttons_ev_status_read() & (1 << (button->num - 1));
+
+	return mp_obj_new_bool(state);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(litex_button_read_status_obj, litex_button_status_read);
+
+STATIC mp_obj_t litex_button_was_pressed(size_t n_args, const mp_obj_t *args) {
+    litex_button_obj_t *button = MP_OBJ_TO_PTR(args[0]);
+    //work out if we should reset the read, default is true
+    bool reset = (n_args < 2) ? true : mp_obj_is_true(args[1]);
+
+    bool state = cas_buttons_ev_pending_read() & (1 << (button->num - 1));
+
+    if (reset) {
+        cas_buttons_ev_pending_write(1 << (button->num - 1));
+    }
+
+    return mp_obj_new_bool(state);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(litex_button_was_pressed_obj, 1, 2, litex_button_was_pressed);
+
+STATIC const mp_rom_map_elem_t litex_button_locals_dict_table[] = {
+	{ MP_OBJ_NEW_QSTR(MP_QSTR_status), MP_ROM_PTR(&litex_button_read_status_obj) },
+	{ MP_OBJ_NEW_QSTR(MP_QSTR_was_pressed), MP_ROM_PTR(&litex_button_was_pressed_obj) },
+
+    //class constants
+    { MP_OBJ_NEW_QSTR(MP_QSTR_NUM_BUTTONS), MP_OBJ_NEW_SMALL_INT(CAS_NUM_BUTTONS) },
+};
+STATIC MP_DEFINE_CONST_DICT(litex_button_locals_dict, litex_button_locals_dict_table);
+
+const mp_obj_type_t litex_button_type = {
+	{ &mp_type_type },
+	.name = MP_QSTR_button,
+	.print = litex_button_print,
+	.make_new = litex_button_make_new,
+	.locals_dict = (mp_obj_t)&litex_button_locals_dict,
+};

--- a/litex/litex_switches.c
+++ b/litex/litex_switches.c
@@ -9,6 +9,7 @@
 #ifndef CSR_CAS_BASE
 static inline void cas_switches_in_read(void) {
 }
+#define CAS_NUM_SWITCHES 0 
 #endif
 
 const mp_obj_type_t litex_switch_type;
@@ -18,39 +19,30 @@ typedef struct _litex_switch_obj_t {
     int num;
 } litex_switch_obj_t;
 
-STATIC litex_switch_obj_t litex_switches[8] = {
-	{{&litex_switch_type}, 1},
-	{{&litex_switch_type}, 2},
-	{{&litex_switch_type}, 3},
-	{{&litex_switch_type}, 4},
-	{{&litex_switch_type}, 5},
-	{{&litex_switch_type}, 6},
-	{{&litex_switch_type}, 7},
-	{{&litex_switch_type}, 8}
-};
-
 STATIC mp_obj_t litex_switch_make_new(const mp_obj_type_t *type_in,
 		size_t n_args, size_t n_kw, const mp_obj_t *args) {
 	mp_arg_check_num(n_args, n_kw, 1, 1, false);
 
 	mp_uint_t switch_num = mp_obj_get_int(args[0]);
 
-	switch (switch_num) {
-	case 1 ... 8:
-		return &litex_switches[switch_num - 1];
-	default:
-		nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+    if ((switch_num < 1) || (switch_num > CAS_NUM_SWITCHES)) {
+        nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
 			"not a valid SWITCH number: %d", switch_num));
-	}
+	} else {
+        litex_switch_obj_t* sw = m_new_obj(litex_switch_obj_t);
+        sw->base.type = type_in;
+        sw->num = switch_num;
+        return MP_OBJ_FROM_PTR(sw);
+    }
 }
 
 void litex_switch_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-	litex_switch_obj_t *self = self_in;
-	mp_printf(print, "SWITCH(%u)", self->num);
+	litex_switch_obj_t *self = MP_OBJ_TO_PTR(self_in);
+	mp_printf(print, "Switch(%u)", self->num);
 }
 
 STATIC mp_obj_t litex_switch_read(mp_obj_t self_in) {
-	litex_switch_obj_t *sw = self_in;
+	litex_switch_obj_t *sw = MP_OBJ_TO_PTR(self_in);
 	bool state = cas_switches_in_read() & (1 << (sw->num - 1));
 
 	return mp_obj_new_bool(state);
@@ -59,8 +51,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(litex_switch_read_obj, litex_switch_read);
 
 
 
-STATIC const mp_map_elem_t litex_switches_locals_dict_table[] = {
-	{ MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&litex_switch_read_obj },
+STATIC const mp_rom_map_elem_t litex_switches_locals_dict_table[] = {
+	{ MP_OBJ_NEW_QSTR(MP_QSTR_read), MP_ROM_PTR(&litex_switch_read_obj) },
+
+    //class constants
+    { MP_OBJ_NEW_QSTR(MP_QSTR_NUM_SWITCHES), MP_OBJ_NEW_SMALL_INT(CAS_NUM_SWITCHES) },
 };
 STATIC MP_DEFINE_CONST_DICT(litex_switches_locals_dict, litex_switches_locals_dict_table);
 

--- a/litex/litex_switches.c
+++ b/litex/litex_switches.c
@@ -1,0 +1,73 @@
+
+#include "py/nlr.h"
+#include "py/obj.h"
+#include "py/runtime.h"
+#include "py/objexcept.h"
+
+#include "generated/csr.h"
+
+#ifndef CSR_CAS_BASE
+static inline void cas_switches_in_read(void) {
+}
+#endif
+
+const mp_obj_type_t litex_switch_type;
+
+typedef struct _litex_switch_obj_t {
+    mp_obj_base_t base;
+    int num;
+} litex_switch_obj_t;
+
+STATIC litex_switch_obj_t litex_switches[8] = {
+	{{&litex_switch_type}, 1},
+	{{&litex_switch_type}, 2},
+	{{&litex_switch_type}, 3},
+	{{&litex_switch_type}, 4},
+	{{&litex_switch_type}, 5},
+	{{&litex_switch_type}, 6},
+	{{&litex_switch_type}, 7},
+	{{&litex_switch_type}, 8}
+};
+
+STATIC mp_obj_t litex_switch_make_new(const mp_obj_type_t *type_in,
+		size_t n_args, size_t n_kw, const mp_obj_t *args) {
+	mp_arg_check_num(n_args, n_kw, 1, 1, false);
+
+	mp_uint_t switch_num = mp_obj_get_int(args[0]);
+
+	switch (switch_num) {
+	case 1 ... 8:
+		return &litex_switches[switch_num - 1];
+	default:
+		nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,
+			"not a valid SWITCH number: %d", switch_num));
+	}
+}
+
+void litex_switch_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+	litex_switch_obj_t *self = self_in;
+	mp_printf(print, "SWITCH(%u)", self->num);
+}
+
+STATIC mp_obj_t litex_switch_read(mp_obj_t self_in) {
+	litex_switch_obj_t *sw = self_in;
+	bool state = cas_switches_in_read() & (1 << (sw->num - 1));
+
+	return mp_obj_new_bool(state);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(litex_switch_read_obj, litex_switch_read);
+
+
+
+STATIC const mp_map_elem_t litex_switches_locals_dict_table[] = {
+	{ MP_OBJ_NEW_QSTR(MP_QSTR_read), (mp_obj_t)&litex_switch_read_obj },
+};
+STATIC MP_DEFINE_CONST_DICT(litex_switches_locals_dict, litex_switches_locals_dict_table);
+
+const mp_obj_type_t litex_switch_type = {
+	{ &mp_type_type },
+	.name = MP_QSTR_SWITCH,
+	.print = litex_switch_print,
+	.make_new = litex_switch_make_new,
+	.locals_dict = (mp_obj_t)&litex_switches_locals_dict,
+};

--- a/litex/modlitex.c
+++ b/litex/modlitex.c
@@ -1,11 +1,13 @@
 #include "py/obj.h"
 
 extern const mp_obj_type_t litex_led_type;
+extern const mp_obj_type_t litex_switch_type;
 
 STATIC const mp_rom_map_elem_t litex_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_litex) },
 
     { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&litex_led_type) },
+    { MP_ROM_QSTR(MP_QSTR_SWITCH), MP_ROM_PTR(&litex_switch_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(litex_module_globals, litex_module_globals_table);

--- a/litex/modlitex.c
+++ b/litex/modlitex.c
@@ -2,12 +2,14 @@
 
 extern const mp_obj_type_t litex_led_type;
 extern const mp_obj_type_t litex_switch_type;
+extern const mp_obj_type_t litex_button_type;
 
 STATIC const mp_rom_map_elem_t litex_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_litex) },
 
-    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&litex_led_type) },
-    { MP_ROM_QSTR(MP_QSTR_SWITCH), MP_ROM_PTR(&litex_switch_type) },
+    { MP_ROM_QSTR(MP_QSTR_Led), MP_ROM_PTR(&litex_led_type) },
+    { MP_ROM_QSTR(MP_QSTR_Switch), MP_ROM_PTR(&litex_switch_type) },
+    { MP_ROM_QSTR(MP_QSTR_Button), MP_ROM_PTR(&litex_button_type) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(litex_module_globals, litex_module_globals_table);


### PR DESCRIPTION
* Added switch and button class
* All classes now named using pep8 standard
* All classes can now use generic number of devices and have class constant to tell you how many there are

TODO: Implement and test IRQ for buttons

requires https://github.com/timvideos/HDMI2USB-litex-firmware/pull/348 to add cas constants 