### PR TITLE
Make it possible to build micropython outside HDMI2USB-litex-firmware repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 # Build directory
 ######################
 build/
+generated/
 
 # Test failure outputs
 ######################

--- a/litex/Makefile
+++ b/litex/Makefile
@@ -15,6 +15,7 @@ To allow MicroPython to find these files, you must do one of the
 following;
  * Set BUILDINC_DIRECTORY.
  * Copy the files into a local generated directory.
+ * Run ./get-gateware.sh script (setting PLATFORM/TARGET value).
 
 endef
 $(error $(ERROR_MSG))

--- a/litex/Makefile
+++ b/litex/Makefile
@@ -1,8 +1,24 @@
-ifeq ($(HDMI2USB_ENV),)
-ifeq ($(BUILDINC_DIRECTORY),)
-$(error Building outside gateware environment. Must set BUILDINC_DIRECTORY to the LiteX generated files (build/software/include/generated/))
-endif
-endif
+BUILDINC_DIRECTORY ?= .
+ifeq ($(wildcard $(BUILDINC_DIRECTORY)/generated/variables.mak),)
+define ERROR_MSG
+
+$(BUILDINC_DIRECTORY)/generated/variables.mak not found.
+
+MicroPython for LiteX requires these generated files to build. It
+is important that the files match the gateware you are using and
+are specific to each board / platform.
+
+The LiteX generated files are found in build output directory
+under "software/include/generated".
+
+To allow MicroPython to find these files, you must do one of the
+following;
+ * Set BUILDINC_DIRECTORY.
+ * Copy the files into a local generated directory.
+
+endef
+$(error $(ERROR_MSG))
+endif # no generated/variables.mak
 include $(BUILDINC_DIRECTORY)/generated/variables.mak
 
 include ../py/mkenv.mk

--- a/litex/get-gateware.sh
+++ b/litex/get-gateware.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+PLATFORM="${PLATFORM:-mimasv2}"
+TARGET="${TARGET:-base}"
+CPU="${CPU:-lm32}"
+BRANCH="${BRANCH:-master}"
+
+GITHUB_URL=https://github.com/timvideos/HDMI2USB-firmware-prebuilt/
+
+# Automatically figure out the latest revision
+if [ "$REV" = "" ]; then
+	REV=$(svn ls $GITHUB_URL/trunk/archive/$BRANCH | sort | tail -n1 | sed -e's-/$--')
+	echo "Using revision $REV"
+fi
+
+# archive/master/v0.0.3-696-g2f815c1/minispartan6/base/lm32
+BASE_DIR=archive/$BRANCH/$REV/$PLATFORM/$TARGET/$CPU
+
+# Get the generated header files
+svn export --force $GITHUB_URL/trunk/$BASE_DIR/software/include/generated | grep -v "^Exported"
+
+# Get the flash file
+#svn export --force $SVN_URL/flash.bin
+
+# Get gateware and bios files (to allow image building)
+#svn export --force $SVN_URL/gateware/top.bin gateware.bin
+#svn export --force $SVN_URL/software/bios/bios.bin


### PR DESCRIPTION
By downloading the headers from the [HDMI2USB prebuilt repo](https://github.com/timvideos/HDMI2USB-firmware-prebuilt) we can make it possible to build micropython without needing the whole [HDMI2USB-litex-firmware](https://github.com/timvideos/HDMI2USB-litex-firmware) repo.

This assumes you have the lm32 toolchain available in your path. You also need subversion installed.